### PR TITLE
Added blurb for using private CA with RKE2 cluster autoscaler

### DIFF
--- a/Integrations/RKE2ClusterAutoscaler/README.md
+++ b/Integrations/RKE2ClusterAutoscaler/README.md
@@ -91,8 +91,7 @@ If you are using a private CA certificate (or self-signed) for Rancher, you will
 
 1. Obtain a copy of the *public* certificate for your CA. PEM format is required.
 2. Create a TLS secret in the namespace in which you are going to install cluster-autoscaler. You can use the Rancher UI for this, or this kubectl command:
-        
-    ```
+    ```bash
     kubectl create secret tls --cert=[certfile.pem] rancher-ca-certificate -n [target namespace]
     ```
 

--- a/Integrations/RKE2ClusterAutoscaler/README.md
+++ b/Integrations/RKE2ClusterAutoscaler/README.md
@@ -91,6 +91,7 @@ If you are using a private CA certificate (or self-signed) for Rancher, you will
 
 1. Obtain a copy of the *public* certificate for your CA. PEM format is required.
 2. Create a TLS secret in the namespace in which you are going to install cluster-autoscaler. You can use the Rancher UI for this, or this kubectl command:
+
     ```bash
     kubectl create secret tls --cert=[certfile.pem] rancher-ca-certificate -n [target namespace]
     ```


### PR DESCRIPTION
This PR adds lines to the RKE2 autoscaler integration docs to discuss how to using a Rancher instance with a private CA certificate. 