### PR TITLE
Extend Kubewarden steps and fix curl issue

### DIFF
--- a/Rodeos/HackingKubernetes/content/step-02.md
+++ b/Rodeos/HackingKubernetes/content/step-02.md
@@ -9,13 +9,13 @@ The victim VM is running an older Ubuntu 18.04 with an outdated kernel that has 
 
 We want to ensure that this VM stays vulnerable and disable unattended upgrades.
 
-```ctr
+```ctr:
 sudo apt remove unattended-upgrades
 ```
 
 Next, we will install some standard packages
 
-```ctr
+```ctr:
 sudo apt-get update
 sudo apt install -y apt-transport-https ca-certificates curl socat jq
 ```
@@ -26,13 +26,18 @@ and an older Docker version:
 curl -fsSl "https://download.docker.com/linux/ubuntu/gpg" | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
 sudo apt install -y docker-ce=18.06.3~ce~3-0~ubuntu
+```
+
+add the ubuntu user to the docker group and create the group docker
+
+```ctr:
 sudo usermod -aG docker ubuntu
 newgrp docker
 ```
 
 We also want to disable and uninstall apparmor
 
-```ctr
+```ctr:
 sudo systemctl disable apparmor
 sudo systemctl stop apparmor
 sudo apt purge -y apparmor

--- a/Rodeos/HackingKubernetes/content/step-17.md
+++ b/Rodeos/HackingKubernetes/content/step-17.md
@@ -46,7 +46,7 @@ ps auxf
 Let's try to install kubectl into the container
 
 ```ctr:
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; chmod +x kubectl; mv kubectl /usr/bin/
+curl -LO --insecure "https://dl.k8s.io/release/$(curl -L -s --insecure https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; chmod +x kubectl; mv kubectl /usr/bin/
 ```
 
 And access the Kubernetes API. This should create an error, because the Pod's ServiceAccount does not have any permissions to access the Kubernetes API:

--- a/Rodeos/HackingKubernetes/content/step-20.md
+++ b/Rodeos/HackingKubernetes/content/step-20.md
@@ -31,7 +31,7 @@ Under **Process Profile Rules**, click on **Actions** and **Add rule**:
 * Path: `/usr/bin/socat`
 * Action: Deny
 
-Execute the socat payload in the remote shell on the attacker01 VM again
+Execute the socat payload in the remote shell on the **attacker01 VM** again
 
 ```ctr:
 sh -c "echo \$\$ > /tmp/cgrp/x/cgroup.procs"

--- a/Rodeos/HackingKubernetes/content/step-24.md
+++ b/Rodeos/HackingKubernetes/content/step-24.md
@@ -7,6 +7,7 @@ After we secured our cluster with NeuVector, we would also take a look into Kube
 We will now install Kubewarden onto our `Victim01` Kubernetes cluster.
 
 First we need to change the protected Mode for the node into discovery and disable Admission Control in NeuVector, that we can run commands on the node and the sample app run again in the cluster.
+
 1. Access NeuVector at [https://neuvector.cattle-neuvector-system.${vminfo:victim01:public_ip}.sslip.io](https://neuvector.cattle-neuvector-system.${vminfo:victim01:public_ip}.sslip.io).
 2. To disable, navigate to **Policy -> Admission Control**, and click the **Status** toggle. The status should now be **Disabled**
 3. Go to **Policy > Groups** and choose the `nodes` group.
@@ -14,7 +15,7 @@ First we need to change the protected Mode for the node into discovery and disab
 
 **Run the following commands on the victim01 VM.**
 
-First we will restart the deployment for the sample app that the application will run again. 
+First we will restart the deployment for the sample app that the application will run again.
 
 ```ctr:
 kubectl restart rollout deployment sample-app
@@ -33,6 +34,7 @@ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewar
 helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
 helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
 ```
+
 This will install kubewarden-crds, kubewarden-controller, and a default PolicyServer on the Kubernetes cluster in the default configuration (which includes self-signed TLS certs).
 
 Now we need to install the kwctl cmd tool to pull the policies from the a artifacthub.io

--- a/Rodeos/HackingKubernetes/content/step-24.md
+++ b/Rodeos/HackingKubernetes/content/step-24.md
@@ -1,41 +1,50 @@
 +++
 title = "Installing Kubewarden"
-weight = 26
+weight = 24
 +++
 
-We will now install Kubewarden onto our `Victim01` Kubernetes cluster. The following command will add `kubewarden` as a helm repository.
+After we secured our cluster with NeuVector, we would also take a look into Kubewarden. Kubewarden is a policy engine for Kubernetes and can extend NeuVector.
+We will now install Kubewarden onto our `Victim01` Kubernetes cluster.
+
+First we need to change the protected Mode for the node into discovery and disable Admission Control in NeuVector, that we can run commands on the node and the sample app run again in the cluster.
+1. Access NeuVector at [https://neuvector.cattle-neuvector-system.${vminfo:victim01:public_ip}.sslip.io](https://neuvector.cattle-neuvector-system.${vminfo:victim01:public_ip}.sslip.io).
+2. To disable, navigate to **Policy -> Admission Control**, and click the **Status** toggle. The status should now be **Disabled**
+3. Go to **Policy > Groups** and choose the `nodes` group.
+4. Switch the mode of the `nodes` group to `Discover`.
 
 **Run the following commands on the victim01 VM.**
 
-```ctr
+First we will restart the deployment for the sample app that the application will run again. 
+
+```ctr:
+kubectl restart rollout deployment sample-app
+```
+
+The following command will add `kubewarden` as a helm repository.
+
+```ctr:
 helm repo add kubewarden https://charts.kubewarden.io
 ```
 
 Next, we can install Kubewarden using `helm install` command. We will install three helm charts.
 
-```ctr
+```ctr:
 helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
-```
-
-```ctr
 helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
-```
-
-```ctr
 helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
 ```
-
 This will install kubewarden-crds, kubewarden-controller, and a default PolicyServer on the Kubernetes cluster in the default configuration (which includes self-signed TLS certs).
 
 Now we need to install the kwctl cmd tool to pull the policies from the a artifacthub.io
 
-```ctr
+```ctr:
 wget https://github.com/kubewarden/kwctl/releases/download/v1.7.0-rc2/default.kwctl-linux-x86_64.kwctl-linux-x86_64.zip
+sudo apt-get install unzip 
 unzip default.kwctl-linux-x86_64.kwctl-linux-x86_64.zip
 ```
 
 For a easy usage we copy the binary into the `/usr/bin directory`
 
-```ctr
+```ctr:
 cp kwctl-linux-x86_64 /usr/bin/kwctl
 ```

--- a/Rodeos/HackingKubernetes/content/step-25.md
+++ b/Rodeos/HackingKubernetes/content/step-25.md
@@ -51,7 +51,7 @@ Now we can apply the policy to our kubernetes cluster
 kubectl apply -f user-group-psp.yaml
 ```
 
-Let us check if the policy is in place. The activation of the policy can take some seconds. 
+Let us check if the policy is in place. The activation of the policy can take some seconds.
 
 ```ctr:
 kubectl get admissionpolicies

--- a/Rodeos/HackingKubernetes/content/step-25.md
+++ b/Rodeos/HackingKubernetes/content/step-25.md
@@ -12,6 +12,12 @@ Now we need to pull the policy to our local datastore
 kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.4.9
 ```
 
+We can check the pulled policies
+
+```ctr:
+kwctl policies
+```
+
 Then we will create a yaml file from that policy to modify the file and put some rules into it.
 
 ```ctr:
@@ -45,7 +51,7 @@ Now we can apply the policy to our kubernetes cluster
 kubectl apply -f user-group-psp.yaml
 ```
 
-Let us check if the policy is in place
+Let us check if the policy is in place. The activation of the policy can take some seconds. 
 
 ```ctr:
 kubectl get admissionpolicies


### PR DESCRIPTION
Separate in Step 2 the creation of the docker group into a new command block, because there where often issues with this cpmmand block. Added the insecure flag to the curl command in Step17 Extend in Step 24 steps to undo NV proctection mode, because if the node is in protected mode we can't install Kubewarden.