### PR TITLE
Update Rancher Rodeo

### DIFF
--- a/Rodeos/Rancher/content/step-2.md
+++ b/Rodeos/Rancher/content/step-2.md
@@ -11,7 +11,7 @@ In this Rodeo we want to create a single node Kubernetes cluster on the `Rancher
 
 ```ctr:Rancher01
 sudo bash -c 'curl -sfL https://get.rke2.io | \
-  INSTALL_RKE2_CHANNEL="v1.26" \
+  INSTALL_RKE2_CHANNEL="v1.27" \
   sh -'
 ```
 

--- a/Rodeos/Rancher/content/step-3.md
+++ b/Rodeos/Rancher/content/step-3.md
@@ -8,7 +8,7 @@ RKE2 now created a new Kubernetes cluster. In order to interact with its API, we
 To install `kubectl` run:
 
 ```ctr:Rancher01
-curl -LO "https://dl.k8s.io/release/v1.26.11/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/release/v1.27.15/bin/linux/amd64/kubectl"
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 ```
 

--- a/Rodeos/Rancher/content/step-5.md
+++ b/Rodeos/Rancher/content/step-5.md
@@ -20,7 +20,7 @@ Now, we can install cert-manager:
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.13.3 \
+  --version v1.15.0 \
   --set installCRDs=true \
   --create-namespace
 ```

--- a/Rodeos/Rancher/content/step-6.md
+++ b/Rodeos/Rancher/content/step-6.md
@@ -18,6 +18,6 @@ helm install rancher rancher-stable/rancher \
   --set hostname=rancher.${vminfo:rancher01:public_ip}.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=RancherOnRKE2 \
-  --version 2.7.9 \
+  --version 2.8.4 \
   --create-namespace
 ```


### PR DESCRIPTION
Changed versions of RKE2, kubectl, cert-manager and Rancher itself to newer versions. 

- RKE2 to version 1.27 (latest)
- kubectl to version 1.27.15
- cert-manager to version 1.15.0
- Rancher to version 2.8.4

RKE2 is on version 1.27 to give the participants the possibilities to perform an upgrade to 1.28 during the webinar.  